### PR TITLE
[CI] Migrate GitHub Actions from Node20 to Node24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,5 +12,5 @@ outputs:
   path:
     description: 'unix path'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'index.js'


### PR DESCRIPTION
## What

Upgrades deprecated/outdated GitHub Actions as part of the org-wide Node20 → Node24 runtime migration (Phase 2 & 3).

### Changes:
- `action.yml`: action.yml runtime node16→node20

## Why

GitHub is enforcing the Node20 runtime for all Actions runners. Actions pinned to older major versions use deprecated Node12/Node16 runtimes and will **stop working** once enforcement begins.

- **`action.yml` runtime `node16` → `node20`**: GitHub requires Node20+ for custom actions.

## How was this tested

- **Custom action runtime**: Test the action in a workflow that uses it. Verify it runs without Node deprecation warnings.

### General:
- All version bumps follow the official migration guides from action maintainers
- No workflow logic was changed beyond action version tags and input name mappings
- Changes will be validated on the next workflow trigger on this branch